### PR TITLE
replace faulty browser-image-resizer lib with testet fork from github…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6886,9 +6886,8 @@
       }
     },
     "browser-image-resizer": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/browser-image-resizer/-/browser-image-resizer-1.2.0.tgz",
-      "integrity": "sha512-xMiB6BnRsD6RWmkD6Av90qXY7uaAOXJPaS5D8cSazyao/bx6ENCm67XGl6BIhn1ETjK52yEs8A/atmMPp74M4A=="
+      "version": "git+https://github.com/misskey-dev/browser-image-resizer.git#eeba31e466b10637c661a1f03ae91c1dd2a4b895",
+      "from": "git+https://github.com/misskey-dev/browser-image-resizer.git"
     },
     "browser-stdout": {
       "version": "1.3.1",
@@ -9821,9 +9820,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/full-icu/-/full-icu-1.3.0.tgz",
       "integrity": "sha512-LGLpSsbkHUT0T+EKrIJltYoejYzUqg1eW+n6wm/FTte1pDiYjeKTxO0uJvrE3jgv6V9eBzMAjF6A8jH16C0+eQ==",
-      "requires": {
-        "icu4c-data": "^0.64.2"
-      },
       "dependencies": {
         "icu4c-data": {
           "version": "0.64.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "abort-controller": "^3.0.0",
     "acorn-dynamic-import": "^4.0.0",
     "async_hooks": "^1.0.0",
-    "browser-image-resizer": "^1.2.0",
+    "browser-image-resizer": "git+https://github.com/misskey-dev/browser-image-resizer.git",
     "caniuse-lite": "^1.0.30001264",
     "cheerio": "^0.22.0",
     "classnames": "^2.2.6",


### PR DESCRIPTION
….com/misskey-dev

No other changes besides uninstalling via npm uninst... and reinstalling from forked github-repo. Testet  for wheelmap.pro. All imports should work the same. Only referenced https://github.com/sozialhelden/wheelmap-frontend/blob/main/src/lib/cache/AccessibilityCloudImageCache.ts here. 

