### PR TITLE
Update .eslintrc.json

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,19 +9,24 @@
     "jsx-a11y"
   ],
   "rules": {
+    "import/prefer-default-export": "off",
     "import/extensions": "off",
+    "react/function-component-definition": "off",
+    "react/react-in-jsx-scope": "off",
+    "react/jsx-filename-extension": [1, { "extensions": [".tsx", ".jsx"] }],
+    "react/require-default-props": "off",
     "semi": ["error", "never"],
     "max-len": ["error", {
       "code": 140,
-      "comments": 80,
+      "comments": 120,
       "ignoreUrls": true,
       "tabWidth": 2
-    }],
-    "indent": ["error", 2],
-    "quote-props": ["error", "as-needed"],
-    "@stylistic/js/max-len": ["error", {
-      "code": 140,
-      "comments": 80,
+      }],
+      "indent": ["error", 2],
+      "quote-props": ["error", "as-needed"],
+      "@stylistic/js/max-len": ["error", {
+        "code": 140,
+      "comments": 120,
       "ignoreUrls": true,
       "tabWidth": 2
     }],
@@ -30,4 +35,3 @@
     "@stylistic/js/quote-props": ["error", "as-needed"]
   }
 }
-

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,25 +13,58 @@
     "import/extensions": "off",
     "react/function-component-definition": "off",
     "react/react-in-jsx-scope": "off",
-    "react/jsx-filename-extension": [1, { "extensions": [".tsx", ".jsx"] }],
+    "react/jsx-filename-extension": [
+      1,
+      {
+        "extensions": [
+          ".tsx",
+          ".jsx"
+        ]
+      }
+    ],
     "react/require-default-props": "off",
-    "semi": ["error", "never"],
-    "max-len": ["error", {
-      "code": 140,
-      "comments": 120,
-      "ignoreUrls": true,
-      "tabWidth": 2
-      }],
-      "indent": ["error", 2],
-      "quote-props": ["error", "as-needed"],
-      "@stylistic/js/max-len": ["error", {
+    "react/jsx-props-no-spreading": "off",
+    "semi": [
+      "error",
+      "never"
+    ],
+    "max-len": [
+      "error",
+      {
         "code": 140,
-      "comments": 120,
-      "ignoreUrls": true,
-      "tabWidth": 2
-    }],
-    "@stylistic/js/indent": ["error", 2],
-    "@stylistic/js/semi": ["error", "never"],
-    "@stylistic/js/quote-props": ["error", "as-needed"]
+        "comments": 120,
+        "ignoreUrls": true,
+        "tabWidth": 2
+      }
+    ],
+    "indent": [
+      "error",
+      2
+    ],
+    "quote-props": [
+      "error",
+      "as-needed"
+    ],
+    "@stylistic/js/max-len": [
+      "error",
+      {
+        "code": 140,
+        "comments": 120,
+        "ignoreUrls": true,
+        "tabWidth": 2
+      }
+    ],
+    "@stylistic/js/indent": [
+      "error",
+      2
+    ],
+    "@stylistic/js/semi": [
+      "error",
+      "never"
+    ],
+    "@stylistic/js/quote-props": [
+      "error",
+      "as-needed"
+    ]
   }
 }


### PR DESCRIPTION
Minor changes to be less quirky on react uses
- default exports are optional
- FCs can declared however you like it
- react does not have to be imported, if it's using components anyway
- comments can be a bit longer, still
- default properties don't have to be passed, if you don't want them
- allowing spreading in react component properties