### PR TITLE
Onboarding Fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6573,7 +6573,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/@turf/turf/-/turf-7.1.0.tgz",
       "integrity": "sha512-7NA6tAjbu9oIvIfpRO5AdPrZbFTlUFU02HVA7sLJM9jFeNIZovW09QuDo23uoS2z5l94SXV1GgKKxN5wo7prCw==",
-      "license": "MIT",
       "dependencies": {
         "@turf/along": "^7.1.0",
         "@turf/angle": "^7.1.0",

--- a/src/components/App/HeadMetaTags.tsx
+++ b/src/components/App/HeadMetaTags.tsx
@@ -48,7 +48,7 @@ export default function HeadMetaTags() {
 
       {/* Relations */}
       <link href="/search" rel="search" title={t`Search`} />
-      <link href="/onboarding" rel="home" title={t`Homepage`} />
+      <link href="/" rel="home" title={t`Homepage`} />
 
       {/* Misc */}
       <meta

--- a/src/components/App/MainMenu/MainMenu.tsx
+++ b/src/components/App/MainMenu/MainMenu.tsx
@@ -339,7 +339,7 @@ export default function MainMenu(props: Props) {
 
   const homeLink = (
     <div className="home-link">
-      <Link href="/onboarding" legacyBehavior>
+      <Link href="/" legacyBehavior>
         <button
           className="btn-unstyled home-button"
           aria-label={t`Home`}

--- a/src/components/App/MapLayout.tsx
+++ b/src/components/App/MapLayout.tsx
@@ -17,7 +17,7 @@ import ErrorBoundary from '../shared/ErrorBoundary'
 import { GlobalMapContextProvider } from '../MapNew/GlobalMapContext'
 import { isFirstStart } from '../../lib/util/savedState'
 
-import Onboarding from '../Onboarding/OnboardinView'
+import Onboarding from '../Onboarding/OnboardingView'
 
 const BlurLayer = styled.div<{ active: boolean }>`
   position: fixed;

--- a/src/components/App/MapLayout.tsx
+++ b/src/components/App/MapLayout.tsx
@@ -15,6 +15,9 @@ import HeadMetaTags from './HeadMetaTags'
 import MainMenu from './MainMenu/MainMenu'
 import ErrorBoundary from '../shared/ErrorBoundary'
 import { GlobalMapContextProvider } from '../MapNew/GlobalMapContext'
+import { isFirstStart } from '../../lib/util/savedState'
+
+import Onboarding from '../Onboarding/OnboardinView'
 
 const BlurLayer = styled.div<{ active: boolean }>`
   position: fixed;
@@ -46,6 +49,7 @@ export default function MapLayout({
   const app = React.useContext(AppContext)
   const { clientSideConfiguration } = app || {}
   const [isMenuOpen, setIsMenuOpen] = React.useState(false)
+  const firstStart = isFirstStart()
   const toggleMainMenu = React.useCallback((newValue?: boolean) => {
     setIsMenuOpen(typeof newValue === 'boolean' ? newValue : !isMenuOpen)
   }, [isMenuOpen])
@@ -60,6 +64,7 @@ export default function MapLayout({
 
   return (
     <ErrorBoundary>
+      {firstStart && <Onboarding />}
       <HeadMetaTags />
       <GlobalStyle />
 

--- a/src/components/CombinedFeaturePanel/CombinedFeaturePanel.tsx
+++ b/src/components/CombinedFeaturePanel/CombinedFeaturePanel.tsx
@@ -1,6 +1,6 @@
 import { Callout, useHotkeys } from '@blueprintjs/core'
 import { uniqBy } from 'lodash'
-import { useMemo, useState } from 'react'
+import React, { useMemo, useState } from 'react'
 import styled from 'styled-components'
 import { t } from 'ttag'
 import {
@@ -60,21 +60,23 @@ export function CombinedFeaturePanel(props: Props) {
   const { handleKeyDown, handleKeyUp } = useHotkeys(hotkeys)
   const surroundings = features && features.length > 1 && features.slice(1)
   return (
-    <ErrorBoundary>
-      <Panel onKeyDown={handleKeyDown} onKeyUp={handleKeyUp}>
-        {features && features[0] && <PlaceOfInterestDetails feature={features[0]} />}
-        {surroundings && surroundings.map((feature) => <FeatureSection key={getKey(feature)} feature={feature} />)}
+    <React.StrictMode>
+      <ErrorBoundary>
+        <Panel onKeyDown={handleKeyDown} onKeyUp={handleKeyUp}>
+          {features && features[0] && <PlaceOfInterestDetails feature={features[0]} />}
+          {surroundings && surroundings.map((feature) => <FeatureSection key={getKey(feature)} feature={feature} />)}
 
-        {(!features || features.length === 0) && (
-          <Callout>
-            <h2>{t`No features found.`}</h2>
-          </Callout>
-        )}
+          {(!features || features.length === 0) && (
+            <Callout>
+              <h2>{t`No features found.`}</h2>
+            </Callout>
+          )}
 
-        <p>
-          {showDebugger && <FeaturesDebugJSON features={features} /> }
-        </p>
-      </Panel>
-    </ErrorBoundary>
+          <p>
+            {showDebugger && <FeaturesDebugJSON features={features} /> }
+          </p>
+        </Panel>
+      </ErrorBoundary>
+    </React.StrictMode>
   )
 }

--- a/src/components/MappingEvents/MappingEventPanel.tsx
+++ b/src/components/MappingEvents/MappingEventPanel.tsx
@@ -205,7 +205,7 @@ export default function MappingEventPanel({ mappingEvent }: Props) {
     trackMappingEventMembershipChanged({
       userUUID, app, reason: 'button', joinedMappingEvent: mappingEvent,
     })
-    router.push(`/events/${mappingEventId}/welcome`)
+    router.push(`/events/${mappingEventId}/welcome`, undefined, { shallow: true })
     mutateMappingEventId()
   }, [mappingEvent, mappingEventId])
 

--- a/src/components/MappingEvents/MappingEventWelcomeDialog.tsx
+++ b/src/components/MappingEvents/MappingEventWelcomeDialog.tsx
@@ -207,7 +207,7 @@ export default function MappingEventWelcomeDialog({
       userUUID, app, reason: 'button', joinedMappingEvent: mappingEvent, emailAddress,
     })
     mutateMappingEventId(null)
-    router.push('/')
+    router.push('/', undefined, { shallow: true })
   }, [mappingEvent, userUUID, mutateMappingEventId, router, app, mappingEventId])
 
   return (

--- a/src/components/Onboarding/LocationFailedStep.tsx
+++ b/src/components/Onboarding/LocationFailedStep.tsx
@@ -1,11 +1,11 @@
-import { FC, useContext } from "react";
-import styled from "styled-components";
-import { AppContext } from "../../lib/context/AppContext";
-import StyledMarkdown from "../shared/StyledMarkdown";
-import { LocationFailedStepPrimaryText, selectProductName } from "./language";
-import { LocationSearch } from "./components/LocationSearch";
-import { KomootPhotonResultFeature } from "../../lib/fetchers/fetchPlacesOnKomootPhoton";
-import { LocationContainer } from "./components/LocationContainer";
+import { FC, useContext } from 'react'
+import styled from 'styled-components'
+import { AppContext } from '../../lib/context/AppContext'
+import StyledMarkdown from '../shared/StyledMarkdown'
+import { LocationFailedStepPrimaryText, selectProductName } from './language'
+import { LocationSearch } from './components/LocationSearch'
+import { KomootPhotonResultFeature } from '../../lib/fetchers/fetchPlacesOnKomootPhoton'
+import { LocationContainer } from './components/LocationContainer'
 
 const Container = styled(LocationContainer)`
   .footer {
@@ -14,23 +14,23 @@ const Container = styled(LocationContainer)`
       flex: 1;
     }
   }
-`;
+`
 
 export const LocationFailedStep: FC<{
   onSubmit: (location?: KomootPhotonResultFeature) => unknown;
 }> = ({ onSubmit }) => {
-  const { clientSideConfiguration } = useContext(AppContext);
+  const { clientSideConfiguration } = useContext(AppContext) ?? { }
 
   return (
     <Container>
       <StyledMarkdown>
         {LocationFailedStepPrimaryText(
-          selectProductName(clientSideConfiguration)
+          selectProductName(clientSideConfiguration),
         )}
       </StyledMarkdown>
       <footer className="footer">
         <LocationSearch onUserSelection={onSubmit} />
       </footer>
     </Container>
-  );
-};
+  )
+}

--- a/src/components/Onboarding/LocationNoPermissionStep.tsx
+++ b/src/components/Onboarding/LocationNoPermissionStep.tsx
@@ -1,12 +1,12 @@
-import { FC, useContext } from "react";
-import styled from "styled-components";
-import { AppContext } from "../../lib/context/AppContext";
-import StyledMarkdown from "../shared/StyledMarkdown";
-import { LocationNoPermissionPrimaryText, selectProductName } from "./language";
-import { LocationSearch } from "./components/LocationSearch";
-import { KomootPhotonResultFeature } from "../../lib/fetchers/fetchPlacesOnKomootPhoton";
-import { getLocationSettingsUrl } from "../../lib/goToLocationSettings";
-import { LocationContainer } from "./components/LocationContainer";
+import { FC, useContext } from 'react'
+import styled from 'styled-components'
+import { AppContext } from '../../lib/context/AppContext'
+import StyledMarkdown from '../shared/StyledMarkdown'
+import { LocationNoPermissionPrimaryText, selectProductName } from './language'
+import { LocationSearch } from './components/LocationSearch'
+import { KomootPhotonResultFeature } from '../../lib/fetchers/fetchPlacesOnKomootPhoton'
+import { getLocationSettingsUrl } from '../../lib/goToLocationSettings'
+import { LocationContainer } from './components/LocationContainer'
 
 const Container = styled(LocationContainer)`
   .footer {
@@ -15,24 +15,24 @@ const Container = styled(LocationContainer)`
       flex: 1;
     }
   }
-`;
+`
 
 export const LocationNoPermissionStep: FC<{
   onSubmit: (location?: KomootPhotonResultFeature) => unknown;
 }> = ({ onSubmit }) => {
-  const { clientSideConfiguration } = useContext(AppContext);
-  const [url] = getLocationSettingsUrl();
+  const { clientSideConfiguration } = useContext(AppContext) ?? { }
+  const [url] = getLocationSettingsUrl()
   return (
     <Container>
       <StyledMarkdown>
         {LocationNoPermissionPrimaryText(
           selectProductName(clientSideConfiguration),
-          url
+          url,
         )}
       </StyledMarkdown>
       <footer className="footer">
         <LocationSearch onUserSelection={onSubmit} />
       </footer>
     </Container>
-  );
-};
+  )
+}

--- a/src/components/Onboarding/LocationStep.tsx
+++ b/src/components/Onboarding/LocationStep.tsx
@@ -1,16 +1,18 @@
-import { FC, useCallback, useEffect, useState } from "react";
-import styled from "styled-components";
-import { cx } from "../../lib/util/cx";
-import { CallToActionButton, SecondaryButton } from "../shared/Button";
-import StyledMarkdown from "../shared/StyledMarkdown";
+import {
+  FC, useCallback, useEffect, useState,
+} from 'react'
+import styled from 'styled-components'
+import { cx } from '../../lib/util/cx'
+import { CallToActionButton, SecondaryButton } from '../shared/Button'
+import StyledMarkdown from '../shared/StyledMarkdown'
 import {
   DenyLocationPermissionText,
   GrantLocationPermissionText,
   LocationStepAdditionalHint,
   LocationStepPrimaryText,
-} from "./language";
-import { getLocationSettingsUrl } from "../../lib/goToLocationSettings";
-import { LocationContainer } from "./components/LocationContainer";
+} from './language'
+import { getLocationSettingsUrl } from '../../lib/goToLocationSettings'
+import { LocationContainer } from './components/LocationContainer'
 
 const Container = styled(LocationContainer)`
   .footer {
@@ -64,7 +66,7 @@ const Container = styled(LocationContainer)`
       }
     }
   }
-`;
+`
 
 const ReducedSecondaryButton = styled(SecondaryButton)`
   // width is 100%
@@ -72,9 +74,9 @@ const ReducedSecondaryButton = styled(SecondaryButton)`
   // conforms more with the call to action button
   padding: 0.5em 0.75em;
   border-radius: 0.5rem;
-`;
+`
 
-type Stage = "idle" | "acquiring" | "failed-not-exited";
+type Stage = 'idle' | 'acquiring' | 'failed-not-exited';
 
 // oeuf, there are many exit points that may be consolidated:
 // permission denied: ok, they denied
@@ -86,50 +88,52 @@ export const LocationStep: FC<{
   onFailed: () => unknown;
   onGeneralError: (error: GeolocationPositionError) => unknown;
   maxRetries?: number;
-}> = ({ onAccept, onFailed, onGeneralError, onRejected, maxRetries = 2 }) => {
-  const [stage, setStage] = useState({ stage: "idle" as Stage, retries: 0 });
+}> = ({
+  onAccept, onFailed, onGeneralError, onRejected, maxRetries = 2,
+}) => {
+  const [stage, setStage] = useState({ stage: 'idle' as Stage, retries: 0 })
 
   useEffect(() => {
     if (!navigator.geolocation) {
       // unsupported feature, default disabled?
-      onFailed();
+      onFailed()
     }
-  }, [onFailed]);
+  }, [onFailed])
 
   // failing to get the permission puts the UI in a failure state, but does not
   // exit. If the user pressed okay, but then denied from the browser
   // we may as well retry and give enough insights
   const requestLocationPermission = useCallback(() => {
-    setStage({ ...stage, stage: "acquiring" });
+    setStage({ ...stage, stage: 'acquiring' })
 
     navigator.geolocation.getCurrentPosition(onAccept, (error) => {
       if (error.code === error.POSITION_UNAVAILABLE) {
-        onAccept();
-        return;
+        onAccept()
+        return
       }
       if (
-        error.code === error.PERMISSION_DENIED ||
-        error.code === error.TIMEOUT
+        error.code === error.PERMISSION_DENIED
+        || error.code === error.TIMEOUT
       ) {
         if (stage.retries >= maxRetries) {
-          onFailed();
-          return;
+          onFailed()
+          return
         }
-        setStage({ stage: "failed-not-exited", retries: stage.retries + 1 });
-        return;
+        setStage({ stage: 'failed-not-exited', retries: stage.retries + 1 })
+        return
       }
 
-      onGeneralError(error);
-    });
-  }, [onAccept, stage, setStage, onGeneralError, maxRetries, onFailed]);
+      onGeneralError(error)
+    })
+  }, [onAccept, stage, setStage, onGeneralError, maxRetries, onFailed])
 
-  const isAcquiring = stage.stage === "acquiring";
-  const [url] = getLocationSettingsUrl();
+  const isAcquiring = stage.stage === 'acquiring'
+  const [url] = getLocationSettingsUrl()
 
   // when retries fail, show an additional hint
   const primaryText = `${LocationStepPrimaryText}${
-    stage.retries > 0 ? `\n\n${LocationStepAdditionalHint(url)}` : ""
-  }`;
+    stage.retries > 0 ? `\n\n${LocationStepAdditionalHint(url)}` : ''
+  }`
 
   return (
     <Container>
@@ -141,12 +145,12 @@ export const LocationStep: FC<{
         </ReducedSecondaryButton>
         <CallToActionButton
           onClick={requestLocationPermission}
-          className={cx("accept", isAcquiring && "active")}
+          className={cx('accept', isAcquiring && 'active')}
         >
           <span className="text">{GrantLocationPermissionText}</span>
           <span className="loader" />
         </CallToActionButton>
       </footer>
     </Container>
-  );
-};
+  )
+}

--- a/src/components/Onboarding/LocationStep.tsx
+++ b/src/components/Onboarding/LocationStep.tsx
@@ -76,7 +76,7 @@ const ReducedSecondaryButton = styled(SecondaryButton)`
   border-radius: 0.5rem;
 `
 
-type Stage = 'idle' | 'acquiring' | 'failed-not-exited';
+type Stage = 'idle' | 'acquiring' | 'failed-not-exited'
 
 // oeuf, there are many exit points that may be consolidated:
 // permission denied: ok, they denied

--- a/src/components/Onboarding/OnboardinView.tsx
+++ b/src/components/Onboarding/OnboardinView.tsx
@@ -1,0 +1,16 @@
+import { useRouter } from 'next/router'
+import React from 'react'
+import OnboardingDialog from './OnboardingDialog'
+import { saveState } from '../../lib/util/savedState'
+import { KomootPhotonResultFeature } from '../../lib/fetchers/fetchPlacesOnKomootPhoton'
+
+export default function Page() {
+  const router = useRouter()
+  const handleClose = React.useCallback((location?: KomootPhotonResultFeature) => {
+    saveState({ onboardingCompleted: 'true' })
+    const query = location ? `?lat=${location.geometry.coordinates[1]}&lon=${location.geometry.coordinates[0]}&zoom=11` : ''
+    router.push(`/${query}`)
+  }, [router])
+
+  return <OnboardingDialog onClose={handleClose} />
+}

--- a/src/components/Onboarding/OnboardingDialog.tsx
+++ b/src/components/Onboarding/OnboardingDialog.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/indent */
 import * as React from 'react'
 import { useCallback, useMemo, useState } from 'react'
 import styled from 'styled-components'
@@ -77,7 +78,8 @@ const StyledModalDialog = styled(ModalDialog)`
     padding: 15px;
     overflow: auto;
     border-radius: 20px;
-    background-color: rgba(255, 255, 255, 0.96);
+    background-color: ${colors.neutralBackgroundColor};
+    color: ${colors.textColor};
     box-shadow: 0 5px 30px rgba(0, 0, 0, 0.15), 0 2px 5px rgba(0, 0, 0, 0.3);
     animation: fadeIn 0.5s linear;
     width: 100%; /* Fix IE 11. @TODO Safe to be moved to ModalDialog component? */
@@ -264,11 +266,11 @@ type OnboardingState =
   | 'onboarding'
   | 'permission'
   | 'no-permission'
-  | 'failed-permission';
+  | 'failed-permission'
 
 type Props = {
   onClose: (location?: KomootPhotonResultFeature) => void;
-};
+}
 
 const OnboardingDialog: React.FC<Props> = ({ onClose }) => {
   const [step, setStep] = useState<OnboardingState>('onboarding')

--- a/src/components/Onboarding/OnboardingStep.tsx
+++ b/src/components/Onboarding/OnboardingStep.tsx
@@ -19,7 +19,7 @@ import {
 export const OnboardingStep: React.FC<{
   onClose?: () => unknown;
 }> = ({ onClose = () => { } }) => {
-  const { clientSideConfiguration } = React.useContext(AppContext)
+  const { clientSideConfiguration } = React.useContext(AppContext) ?? { }
   const headerMarkdownHTML = selectHeaderMarkdownHTML(clientSideConfiguration)
 
   const callToActionButton = React.createRef<HTMLButtonElement>()
@@ -40,7 +40,7 @@ export const OnboardingStep: React.FC<{
       <header>
         <VectorImage
           className="logo"
-          svg={clientSideConfiguration.branding?.vectorLogoSVG}
+          svg={clientSideConfiguration?.branding?.vectorLogoSVG}
           aria-label={selectProductName(clientSideConfiguration)}
           maxHeight="50px"
           maxWidth="200px"

--- a/src/components/Onboarding/OnboardingView.tsx
+++ b/src/components/Onboarding/OnboardingView.tsx
@@ -9,7 +9,7 @@ export default function Page() {
   const handleClose = React.useCallback((location?: KomootPhotonResultFeature) => {
     saveState({ onboardingCompleted: 'true' })
     const query = location ? `?lat=${location.geometry.coordinates[1]}&lon=${location.geometry.coordinates[0]}&zoom=11` : ''
-    router.push(`/${query}`)
+    router.push(`/${query}`, undefined, { shallow: true })
   }, [router])
 
   return <OnboardingDialog onClose={handleClose} />

--- a/src/components/Onboarding/components/LocationContainer.tsx
+++ b/src/components/Onboarding/components/LocationContainer.tsx
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import styled from 'styled-components'
 
 export const LocationContainer = styled.div`
   display: flex;
@@ -27,4 +27,4 @@ export const LocationContainer = styled.div`
     align-self: center;
     gap: 24px;
   }
-`;
+`

--- a/src/components/Onboarding/components/LocationSearch.tsx
+++ b/src/components/Onboarding/components/LocationSearch.tsx
@@ -23,6 +23,7 @@ import { CallToActionButton } from '../../shared/Button'
 import { SearchConfirmText, SearchSkipText } from '../language'
 import CountryContext from '../../../lib/context/CountryContext'
 import fetchCountryGeometry from '../../../lib/fetchers/fetchCountryGeometry'
+import colors from '../../../lib/util/colors'
 
 export const LocationSearch: FC<{ onUserSelection: (selection?: KomootPhotonResultFeature) => unknown }> = ({ onUserSelection }) => {
   const [{ value, origin, selection }, setValue] = useState({ value: '', origin: 'system', selection: '' })
@@ -34,17 +35,20 @@ export const LocationSearch: FC<{ onUserSelection: (selection?: KomootPhotonResu
       return undefined
     }
 
-    const location = regionGeometry.features.find((x) => x.properties['ISO3166-1'] === region)
+    const location = regionGeometry.features.find((x) => x.properties?.['ISO3166-1'] === region)
 
-    let center: Point
-    if ('centroid' in location) {
-      center = location.centroid as Point
-    } else {
-      center = turfCenter(location).geometry
+    let center: Point | undefined
+    if (location) {
+      if ('centroid' in location) {
+        center = location.centroid as Point
+      } else {
+        center = turfCenter(location).geometry
+      }
     }
+
     const computedBias = {
-      lon: center.coordinates[0].toString(),
-      lat: center.coordinates[1].toString(),
+      lon: center?.coordinates[0].toString(),
+      lat: center?.coordinates[1].toString(),
       zoom: '5',
       location_bias_scale: '1.0',
     } as const
@@ -56,7 +60,7 @@ export const LocationSearch: FC<{ onUserSelection: (selection?: KomootPhotonResu
     if (!data) {
       return []
     }
-    const bucket: ({key: string} & KomootPhotonResultFeature)[] = []
+    const bucket: ({ key: string } & KomootPhotonResultFeature)[] = []
     for (let i = 0; i < data.features.length; i += 1) {
       const entry = data.features[i]
       if (!entry.properties) {
@@ -155,7 +159,8 @@ export const LocationSearch: FC<{ onUserSelection: (selection?: KomootPhotonResu
               style={{
                 ...floatingStyles,
                 overflowY: 'auto',
-                background: '#eee',
+                background: colors.neutralBackgroundColor,
+                color: colors.textColor,
                 minWidth: 100,
                 borderRadius: 8,
                 outline: 0,

--- a/src/components/Onboarding/language.ts
+++ b/src/components/Onboarding/language.ts
@@ -10,20 +10,23 @@ import { ClientSideConfiguration } from '../../lib/model/ac/ClientSideConfigurat
 
 // select a white label product name
 export const selectProductName = (
-  clientSideConfiguration: ClientSideConfiguration,
+  clientSideConfiguration: ClientSideConfiguration | undefined,
 ) => translatedStringFromObject(
-  clientSideConfiguration.textContent?.product.name,
+  clientSideConfiguration?.textContent?.product?.name,
 ) || 'Wheelmap'
 
 // translator: Button caption shown on the onboarding screen. To find it, click the logo at the top.
 export const selectHeaderMarkdownHTML = (
-  clientSideConfiguration: ClientSideConfiguration,
+  clientSideConfiguration: ClientSideConfiguration | undefined,
 ) => {
+  if (!clientSideConfiguration) {
+    return undefined
+  }
   const { headerMarkdown } = clientSideConfiguration.textContent
     ?.onboarding || {
     headerMarkdown: undefined,
   }
-  return headerMarkdown && parse(translatedStringFromObject(headerMarkdown))
+  return headerMarkdown && parse(translatedStringFromObject(headerMarkdown) ?? '')
 }
 
 // translator: Shown on the onboarding screen. To find it, click the logo at the top.

--- a/src/components/shared/VectorImage.tsx
+++ b/src/components/shared/VectorImage.tsx
@@ -6,14 +6,14 @@ type ContainerProps = {
   maxWidth?: string,
   maxHeight?: string,
   hasShadow?: boolean,
-};
+}
 
 export const shadowCSS = css`
   filter: drop-shadow(0 2px 0px rgba(0, 0, 0, 0.06)) drop-shadow(0 5px 10px rgba(0, 0, 0, 0.06));
 `
 
 const Container = styled.span <
-  ContainerProps >`
+ContainerProps >`
 display: inline-block;
 vertical-align: middle;
 svg {
@@ -23,10 +23,11 @@ svg {
 }
 `
 
-type Props = ContainerProps &
-  React.HTMLAttributes<HTMLSpanElement> & {
-    svg: ISVGOResult,
-  };
+type Props =
+& ContainerProps
+& React.HTMLAttributes<HTMLSpanElement> & {
+  svg: ISVGOResult | undefined,
+}
 
 export default function VectorImage(props: Props) {
   const svgSource = props.svg?.data

--- a/src/lib/i18n/translatedStringFromObject.ts
+++ b/src/lib/i18n/translatedStringFromObject.ts
@@ -5,7 +5,7 @@ import { currentLocales } from './i18n'
 import { LocalizedString } from './LocalizedString'
 
 export function translatedStringFromObject(
-  string: LocalizedString,
+  string: LocalizedString | null | undefined,
 ): string | null {
   if (typeof string === 'undefined' || string === null) {
     return null

--- a/src/pages/[placeType]/[id]/[tag]/edit.tsx
+++ b/src/pages/[placeType]/[id]/[tag]/edit.tsx
@@ -96,7 +96,7 @@ export default function CompositeFeaturesPage() {
   const feature = features.data?.find((f) => isOSMFeature(f) && f._id === id)
   const osmFeature = isOSMFeature(feature) ? feature : null
   const closeEditor = React.useCallback(() => {
-    router.push(`/composite/${ids}`)
+    router.push(`/composite/${ids}`, undefined, { shallow: true })
   }, [router, ids])
   const [editedTagValue, setEditedTagValue] = React.useState<string | undefined>(feature?.properties[tagName])
   const osmType = getOSMType(osmFeature)

--- a/src/pages/[placeType]/[id]/images/upload.tsx
+++ b/src/pages/[placeType]/[id]/images/upload.tsx
@@ -27,7 +27,7 @@ export default function Page() {
   // />
 
   const closeToolbar = useCallback(() => {
-    router.push(`/${placeType}/${id}`)
+    router.push(`/${placeType}/${id}`, undefined, { shallow: true })
   }, [router, placeType, id])
 
   const [waitingForPhotoUpload, setWaitingForPhotoUpload] = React.useState(
@@ -52,7 +52,7 @@ export default function Page() {
         )
       }
 
-      router.push(`/${placeType}/${id}`)
+      router.push(`/${placeType}/${id}`, undefined, { shallow: true })
     },
     [router, placeType, id, appToken],
   )

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,9 +1,8 @@
 import { useRouter } from 'next/router'
-import React, { useEffect } from 'react'
+import React, { useEffect, ReactElement } from 'react'
 import { isFirstStart } from '../lib/util/savedState'
 import { SearchButtonOrInput } from '../components/SearchPanel/SearchButtonOrInput'
-import { ReactElement } from 'react'
-import Layout from '../components/App/Layout'
+import Layout from '../components/App/MapLayout'
 
 export default function Page() {
   const router = useRouter()

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,6 +2,8 @@ import { useRouter } from 'next/router'
 import React, { useEffect } from 'react'
 import { isFirstStart } from '../lib/util/savedState'
 import { SearchButtonOrInput } from '../components/SearchPanel/SearchButtonOrInput'
+import { ReactElement } from 'react'
+import Layout from '../components/App/Layout'
 
 export default function Page() {
   const router = useRouter()
@@ -15,4 +17,8 @@ export default function Page() {
   return (
     <SearchButtonOrInput />
   )
+}
+
+Page.getLayout = function getLayout(page: ReactElement) {
+  return <Layout>{page}</Layout>
 }

--- a/src/pages/onboarding/index.tsx
+++ b/src/pages/onboarding/index.tsx
@@ -1,17 +1,4 @@
-import { useRouter } from 'next/router'
-import React, { ReactElement } from 'react'
-import MapLayout from '../../components/App/MapLayout'
-import OnboardingDialog from '../../components/Onboarding/OnboardingDialog'
-import { saveState } from '../../lib/util/savedState'
-import { KomootPhotonResultFeature } from '../../lib/fetchers/fetchPlacesOnKomootPhoton'
+import IndexPage from '../index'
 
-export default function Page() {
-  const router = useRouter()
-  const handleClose = React.useCallback((location?: KomootPhotonResultFeature) => {
-    saveState({ onboardingCompleted: 'true' })
-    const query = location ? `?lat=${location.geometry.coordinates[1]}&lon=${location.geometry.coordinates[0]}&zoom=11` : ''
-    router.push(`/${query}`)
-  }, [router])
-
-  return <OnboardingDialog onClose={handleClose} />
-}
+// onboarding is obsolete, it's overlaying itself in all cases over the entire app
+export default IndexPage

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -31,7 +31,7 @@ export default function Page() {
           toilet: null,
           wheelchair: null,
         },
-      })
+      }, undefined, { shallow: true })
     },
     [router],
   )
@@ -41,7 +41,7 @@ export default function Page() {
   const closeSearchPanel = useCallback(() => {
     router.push({
       pathname: '/',
-    })
+    }, undefined, { shallow: true })
   }, [router])
 
   const { clientSideConfiguration } = useCurrentApp()


### PR DESCRIPTION
- enforcing onboarding to show always
- falling back to `index` view for now-obsolete `/onboarding` uri
- replacing `/onboarding` links to `/` (because it has the same functionality
- removing the `/index` route functionality to redirect to `/onboarding`
- fixing dreaded "Loading initial props cancelled" (via: https://github.com/vercel/next.js/discussions/21073#discussioncomment-4449302)