### PR TITLE
fix: link to next accessible toilet

### DIFF
--- a/src/components/CombinedFeaturePanel/components/AccessibilitySection/NextToiletDirections.tsx
+++ b/src/components/CombinedFeaturePanel/components/AccessibilitySection/NextToiletDirections.tsx
@@ -37,7 +37,9 @@ export default function NextToiletDirections({ feature }: { feature: AnyFeature 
   )
 
   return (
-    <Link href={`/${nextToilet.properties._id}`}>
+    // TODO this is not a very good solution. In the future, we should take a look
+    // at routing and make sure that something like '/amenities/way/1234" also works
+    <Link href={`/amenities/${nextToilet.properties._id.replace('/', ':')}`}>
       {caption}
       {distanceElement}
     </Link>

--- a/src/lib/fetchers/osm-api/fetchNearbyFeatures.ts
+++ b/src/lib/fetchers/osm-api/fetchNearbyFeatures.ts
@@ -18,7 +18,7 @@ export default function fetchNearbyFeatures([
   return fetchOSMFeatureCollection([
     baseUrl,
     type,
-    `next=${next}&lon=${lon}&lat=${lat}${urlParams ? `&${urlParams}` : ''}`,
+    `nearest=${next}&lon=${lon}&lat=${lat}${urlParams ? `&${urlParams}` : ''}`,
   ])
 }
 
@@ -32,7 +32,7 @@ export function useNearbyFeatures(
 
   const { baseUrl } = useOSMAPI({ cached: true })
   const { coordinates: [longitude, latitude] } = osmFeature?.centroid || acFeature?.geometry || { coordinates: [undefined, undefined] }
-  const urlParams = tagFilter ? Object.entries(tagFilter).map(([key, value]) => `next_t[${key}]=${value}`).join('&') : ''
+  const urlParams = tagFilter ? Object.entries(tagFilter).map(([key, value]) => `nearest_t[${key}]=${value}`).join('&') : ''
   const response = useSWR(
     feature && baseUrl && latitude && longitude
     && [baseUrl, 'buildings', nearbyFeatureCollectionName, longitude, latitude, urlParams],
@@ -40,8 +40,8 @@ export function useNearbyFeatures(
   )
   const nearbyFeatures = response.data?.features?.map((f) => ({
     properties: {
-      _id: f.properties[`next:${nearbyFeatureCollectionName}:id`],
-      distance: f.properties[`next:${nearbyFeatureCollectionName}:distance`],
+      _id: f.properties[`nearest:${nearbyFeatureCollectionName}:id`],
+      distance: f.properties[`nearest:${nearbyFeatureCollectionName}:distance`],
     },
   }))
 


### PR DESCRIPTION
This fixes the link to the next accessible toilet in a11ymap that will be shown if a place doesn't have one. The underlying issue was a wrongly named query parameter.

The `id` returned from the osm-api backend service for the next accessible toilet contains a slash (e.g. `way/1234`), which is currently not supported by the routing configuration which expects `way:1234`. To make it work, I replaced it with a colon as a temporary solution. In the future, I think we should take a look at routing and make sure a route like `/amenities/way/1234` also works.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208533441124221