### PR TITLE
fix: legacy link to next accessible toilet

### DIFF
--- a/src/lib/getToiletsNearby.ts
+++ b/src/lib/getToiletsNearby.ts
@@ -36,7 +36,7 @@ function calculateBoundingBox(lat: number, lon: number, radius: number) {
 
 function fetchWheelmapToiletPlaces(lat: number, lon: number, radius: number): Promise<Feature[]> {
   const bbox = calculateBoundingBox(lat, lon, radius);
-  const url = `${config.wheelmapApiBaseUrl}/api/nodes?bbox=${bbox.west},${bbox.south},${bbox.east},${bbox.north}&per_page=20&wheelchair=yes&wheelchair_toilet=yes&api_key=${config.wheelmapApiKey}`;
+  const url = `${config.wheelmapApiBaseUrl}/api/nodes?bbox=${bbox.west},${bbox.south},${bbox.east},${bbox.north}&limit=20&hasAccessibleToilet=yes&api_key=${config.wheelmapApiKey}`;
 
   return globalFetchManager
     .fetch(url)


### PR DESCRIPTION
This fixes the link to the next accessible toilet in the current version of the Wheelmap. I'm not 100% sure as I'm quite new to the project and codebase, but it seems like the query parameters of the osm-api have changed in the past and were not updated for the nearby toilets API call.