### PR TITLE
Small type change to improve i18n API

### DIFF
--- a/src/lib/i18n/translatedStringFromObject.ts
+++ b/src/lib/i18n/translatedStringFromObject.ts
@@ -2,13 +2,13 @@ import compact from 'lodash/compact'
 import uniq from 'lodash/uniq'
 import { normalizeLanguageCode } from './normalizeLanguageCode'
 import { currentLocales } from './i18n'
-import { LocalizedString } from './LocalizedString'
+import type { LocalizedString } from './LocalizedString'
 
 export function translatedStringFromObject(
   string: LocalizedString | null | undefined,
-): string | null {
+): string | undefined {
   if (typeof string === 'undefined' || string === null) {
-    return null
+    return undefined
   }
 
   if (typeof string === 'string') return string
@@ -46,5 +46,5 @@ export function translatedStringFromObject(
     if (foundLocale) return string[foundLocale]
   }
 
-  return null
+  return undefined
 }


### PR DESCRIPTION
This simplifies the typing for `translatedStringFromObject()` users a bit.

Using `undefined` as return value is better than `null`. There is no need to *explicitly* return "There is no value!", which simplifies type annotations for all consumers.