### PR TITLE
Add theme (incl. dark mode) support to category/a11y filters

### DIFF
--- a/src/components/SearchPanel/AccessibilityFilterButton.tsx
+++ b/src/components/SearchPanel/AccessibilityFilterButton.tsx
@@ -25,7 +25,7 @@ type Props = {
 
 export const Caption = styled.span`
   flex: 1;
-  color: ${colors.darkSelectedColor};
+  color: var(--accent-a12);
 `
 
 function AccessibilityFilterButton(props: Props) {
@@ -91,12 +91,12 @@ export default styled(AccessibilityFilterButton)`
 
     ${(props) => props.isActive
       && css`
-        background-color: ${colors.coldBackgroundColor};
+        background-color: var(--color-panel-translucent);
       `};
 
     &:hover,
     &:focus {
-      background-color: ${colors.linkBackgroundColorTransparent};
+      background-color: var(--color-surface);
     }
   }
 `

--- a/src/components/SearchPanel/AccessibilityFilterMenu.tsx
+++ b/src/components/SearchPanel/AccessibilityFilterMenu.tsx
@@ -5,9 +5,8 @@ import { t } from 'ttag'
 import {
   yesNoUnknownArray,
 } from '../../lib/model/ac/Feature'
-import colors from '../../lib/util/colors'
 import AccessibilityFilterButton from './AccessibilityFilterButton'
-import { PlaceFilter } from './AccessibilityFilterModel'
+import type { PlaceFilter } from './AccessibilityFilterModel'
 
 type Props = PlaceFilter & {
   className?: string;
@@ -111,7 +110,7 @@ function AccessibilityFilterMenu(props: Props) {
 }
 
 const StyledAccessibilityFilterMenu = styled(AccessibilityFilterMenu)`
-    border-top: 1px solid ${colors.borderColor};
+    border-top: 1px solid var(--gray-4);
 
     header {
         display: flex;

--- a/src/components/SearchPanel/CategoryButton.tsx
+++ b/src/components/SearchPanel/CategoryButton.tsx
@@ -3,7 +3,6 @@ import { t } from 'ttag'
 
 import { YesNoLimitedUnknown, YesNoUnknown } from '../../lib/model/ac/Feature'
 import { isAccessibilityFiltered } from '../../lib/model/ac/filterAccessibility'
-import colors from '../../lib/util/colors'
 import CloseIcon from '../icons/actions/Close'
 import IconButton, { Caption, Circle } from '../shared/IconButton'
 import CombinedIcon from './CombinedIcon'
@@ -31,7 +30,7 @@ export const StyledCategoryIconButton = styled(IconButton)`
   }
 
   ${Circle} {
-    background-color: ${colors.tonedDownSelectedColor};
+    background-color: var(--accent-a11);
     margin: 2.5px;
 
     svg.icon {
@@ -50,24 +49,24 @@ export const StyledCategoryIconButton = styled(IconButton)`
   }
 
   &.active {
-    background-color: ${colors.coldBackgroundColor};
+    background-color: var(--color-panel-translucent);
 
     ${Circle} {
-      background-color: ${colors.selectedColor};
+      background-color: var(--color-surface);
     }
   }
 
   &:hover,
   &:focus {
-    background-color: ${colors.linkBackgroundColorTransparent};
+    background-color: var(--color-surface);
 
     ${Circle} {
-      background-color: ${colors.halfTonedDownSelectedColor};
+      background-color: var(--accent-11);
     }
 
     &.active {
       ${Circle} {
-        background-color: ${colors.tonedDownSelectedColor};
+        background-color: var(--accent-a12);
       }
     }
   }
@@ -82,7 +81,7 @@ export const StyledCategoryIconButton = styled(IconButton)`
       ${Caption} {
           font-size: 0.8em;
           margin-top: 0.5em;
-          color: ${colors.darkSelectedColor};
+          color: var(--accent-12);
       }
   }
 
@@ -104,7 +103,7 @@ export const StyledCategoryIconButton = styled(IconButton)`
           flex: 1;
           justify-content: flex-start;
           display: flex;
-          color: ${colors.darkSelectedColor};
+          color: var(--accent-12);
       }
   }
 `

--- a/src/components/SearchPanel/CategoryMenu.tsx
+++ b/src/components/SearchPanel/CategoryMenu.tsx
@@ -4,7 +4,7 @@ import map from 'lodash/map'
 
 import { Circle } from '../shared/IconButton'
 import CategoryButton from './CategoryButton'
-import { YesNoLimitedUnknown, YesNoUnknown } from '../../lib/model/ac/Feature'
+import type { YesNoLimitedUnknown, YesNoUnknown } from '../../lib/model/ac/Feature'
 import { isAccessibilityFiltered } from '../../lib/model/ac/filterAccessibility'
 import { getRootCategoryTable } from '../../lib/model/ac/categories/getRootCategoryTable'
 


### PR DESCRIPTION
This just uses the correct CSS colors for the filtering UI, improving its look'n'feel in both bright and dark modes.