### PR TITLE
fix: feature panel rerendering

### DIFF
--- a/src/components/CombinedFeaturePanel/FeaturePanelContext.tsx
+++ b/src/components/CombinedFeaturePanel/FeaturePanelContext.tsx
@@ -142,7 +142,7 @@ export function FeaturePanelContextProvider(
           <p className="_title">{t`Loading further details…`}</p>
         </StyledLoadingDiv>
       )}
-      {(!anyLoading && !false) && children}
+      {children}
     </FeaturePanelContext.Provider>
   )
 }

--- a/src/components/CombinedFeaturePanel/components/Gallery/Gallery.tsx
+++ b/src/components/CombinedFeaturePanel/components/Gallery/Gallery.tsx
@@ -98,7 +98,14 @@ export const Gallery: FC<{
     if (activeImageId) goTo(activeImageId);
   }, [images, activeImageId]);
 
-  // Reset the url when closing the dialog
+  // Reset the url when closing the dialog. This is not using react router on purpose.
+  // When using react-router it will re-render the whole FeaturePanel, because it's a
+  // new page. This introduces lag, and we want the dialog to open immediately after
+  // clicking on the image. This is temporary, the proper solution should be to use
+  // a catch-all router in the `[placeType]/[id]/index.tsx` and handle different
+  // nested-routes like image upload or fullscreen image there, without re-rendering
+  // the whole FeaturePanel.
+  // TODO: replace with catch-all route
   // biome-ignore lint/correctness/useExhaustiveDependencies:
   useEffect(() => {
     if (
@@ -106,7 +113,7 @@ export const Gallery: FC<{
       activeImage &&
       window.location.pathname !== baseFeatureUrl
     ) {
-      router.push(baseFeatureUrl);
+      window.history.replaceState(null, document.title, baseFeatureUrl);
     }
   }, [isDialogOpen]);
 
@@ -118,9 +125,9 @@ export const Gallery: FC<{
     }
     const url = getDetailPageUrl(activeImage._id);
     if (url !== window.location.pathname) {
-      router.push(url, undefined, { shallow: true });
+      window.history.replaceState(null, document.title, url);
     }
-  }, [activeImage]);
+  }, [isDialogOpen, activeImage]);
 
   // The Dialog component can autofocus on its own, when using the Dialog.Trigger component.
   // But in this case, we want to focus the currently active image and not the one that actually

--- a/src/components/CombinedFeaturePanel/components/Gallery/Gallery.tsx
+++ b/src/components/CombinedFeaturePanel/components/Gallery/Gallery.tsx
@@ -129,7 +129,7 @@ export const Gallery: FC<{
   const handleOnCloseAutoFocus = (event: Event) => {
     event.preventDefault();
     document
-      .querySelector<HTMLAnchorElement>(`[data-image-id=${activeImage?._id}]`)
+      .querySelector<HTMLAnchorElement>(`[data-image-id="${activeImage?._id}"]`)
       ?.focus();
   };
 


### PR DESCRIPTION
This fixes the re-rendering of the FeaturePanel and some flickering in the newly added image gallery. The fix for the image gallery that circumvents react-router should be a temporary one. As far as I understand, the best practise would be to have a single page for the FeaturePanel with a catch-all route that handles child-routes like image upload or the gallery dynamically instead of creating separate pages for them. I think, this is a pattern we should use in general when dealing with dialogs/modals that have their own route. I'm eager to hear your opinion on this issue @opyh @Mayaryin 