### PR TITLE
Add Biome pre-commit linting with husky

### DIFF
--- a/src/lib/fetchers/callBackendToUpdateInhouseDb.ts
+++ b/src/lib/fetchers/callBackendToUpdateInhouseDb.ts
@@ -4,10 +4,12 @@ export async function callBackendToUpdateInhouseDb({
   baseUrl,
   osmId,
   osmType,
+  tagName,
 }: {
   baseUrl: string;
   osmId: string;
   osmType: string;
+  tagName: string;
 }) {
   log.log('writeChangesToInhouseDb', osmType, osmId)
   const osmIdAsNumber = osmId.replace(/\D/g, '')
@@ -18,6 +20,7 @@ export async function callBackendToUpdateInhouseDb({
     },
     method: 'POST',
     mode: 'cors',
+    body: tagName
   })
 
   if (!response.ok) {

--- a/src/lib/fetchers/osm-api/makeChangeRequestToOsmApi.ts
+++ b/src/lib/fetchers/osm-api/makeChangeRequestToOsmApi.ts
@@ -1,7 +1,6 @@
 import React from 'react'
 import { SWRResponse } from 'swr'
 import { log } from '../../util/logger'
-import { ChangesetState } from './ChangesetState'
 import { callBackendToUpdateInhouseDb } from '../callBackendToUpdateInhouseDb'
 import useOSMAPI from './useOSMAPI'
 
@@ -153,7 +152,7 @@ export default function useSubmitNewValueCallback({
       changesetComplete = true
 
       await callBackendToUpdateInhouseDb({
-        baseUrl: inhouseBaseUrl, osmType, osmId,
+        baseUrl: inhouseBaseUrl, osmType, osmId, tagName
       })
 
       handleSuccess()


### PR DESCRIPTION
Do your sled-related pull requests always get refused? This won't happen anymore with [husky](https://typicode.github.io/husky/). One could say this good boi is really…committed!

![laughing husky from the "pun dog" meme](https://github.com/user-attachments/assets/3918a4f0-d8e3-47a3-a813-1e16b8a34a54)

Back to work. This PR changes the commit process: When you commit files, the staged files (no other files) are automatically formatted and linted. The pre-commit hook will add the automatic changes to the current commit. For new developers, running `npm` once will install husky (=the pre-commit system) automatically.

📎 [Related Ticket](https://app.asana.com/0/1207796396670749/1209169197068565)

## 🔍 Reviewing

To test this, check out the PR, run `npm run dev` (to install the husky pre-commit hook as side effect), then change a JS/TS file and create a test commit. husky will run Biome to automatically format/lint the changed JS/TS file. The system won't touch non-changed files to reduce merge conflicts.

## ⚠️ Creation checklist

<details><summary>🧼 I have cleaned up my code</summary>
  
- [x] My code does not generate new warnings.
- [x] My code does not depend on new vulnerable packages.
- [x] The commit messages are precise and make sense (rebase the PR with `--interactive` if applicable, keeping commits in sensible chunks if possible).
</details>

<details><summary>🔍 I have performed a self-review of my code</summary>
  
- [x] My code is self-documenting or has links to necessary documentation.
- [x] New function and variables names can be understood by new developers with basic project knowledge.
- [x] The feature fits the design.
</details> 

<details><summary>📝 I updated the documentation</summary>
  - [x] I updated the documentation in this repository.
</details> 

