### PR TITLE
Fix/edit button location

### DIFF
--- a/src/components/CombinedFeaturePanel/components/AccessibilitySection/OSMTagProps.tsx
+++ b/src/components/CombinedFeaturePanel/components/AccessibilitySection/OSMTagProps.tsx
@@ -8,6 +8,7 @@ export type OSMTagProps = {
   valueElement: React.ReactNode;
   isEditable: boolean;
   isLanguageTagged: boolean;
+  isDescription: boolean;
   valueDetails?: string;
   keyDetails?: string;
   keyAttribute?: IAccessibilityAttribute;

--- a/src/components/CombinedFeaturePanel/components/AccessibilitySection/OSMTagTableRowOrListElement.tsx
+++ b/src/components/CombinedFeaturePanel/components/AccessibilitySection/OSMTagTableRowOrListElement.tsx
@@ -28,7 +28,6 @@ export function OSMTagTableRowOrListElement({
   keyLabel,
   valueElement,
   isEditable,
-  isLanguageTagged,
   isDescription,
   keyDetails,
   valueDetails,

--- a/src/components/CombinedFeaturePanel/components/AccessibilitySection/OSMTagTableRowOrListElement.tsx
+++ b/src/components/CombinedFeaturePanel/components/AccessibilitySection/OSMTagTableRowOrListElement.tsx
@@ -29,6 +29,7 @@ export function OSMTagTableRowOrListElement({
   valueElement,
   isEditable,
   isLanguageTagged,
+  isDescription,
   keyDetails,
   valueDetails,
   isHorizontal,
@@ -73,7 +74,7 @@ export function OSMTagTableRowOrListElement({
   const valueIsString = typeof valueElement === "string";
   const valueIsNumber = typeof valueElement === "number";
 
-  const editControls = isLanguageTagged ? (
+  const editControls = isDescription ? (
     <EditDropdownMenu tagKey={tagKey} />
   ) : isEditable ? (
     <EditButton tagKey={tagKey} addNewLanguage={false} />

--- a/src/domains/edit/components/AutoEditor.tsx
+++ b/src/domains/edit/components/AutoEditor.tsx
@@ -29,7 +29,7 @@ import { WheelchairEditor } from "./WheelchairEditor";
 
 function getEditorForKey(key: string): React.FC<BaseEditorProps> | undefined {
   switch (true) {
-    case key.startsWith("wheelchair:description"):
+    case key.includes("description"):
       return StringFieldEditor;
 
     case key === "wheelchair":

--- a/src/domains/edit/components/StringFieldEditor.tsx
+++ b/src/domains/edit/components/StringFieldEditor.tsx
@@ -56,9 +56,13 @@ export const StringFieldEditor: React.FC<BaseEditorProps> = ({
   const [hasValueChanged, setHasValueChanged] = useState(false);
 
   const dialogDescription = addNewLanguage
-    ? t(
-        "Please describe how accessible this place is for wheelchair users. Start by selecting the language for your description.",
-      )
+    ? tagKey.includes("wheelchair:description")
+      ? t(
+          "Please describe how accessible this place is for wheelchair users. Start by selecting the language for your description.",
+        )
+      : t(
+          "Please describe this place. Start by selecting the language for your description.",
+        )
     : t("Please edit this description in the same language.");
 
   const textAreaRef = useRef<HTMLTextAreaElement | null>(null);

--- a/src/lib/model/osm/tag-config/editableKeys.ts
+++ b/src/lib/model/osm/tag-config/editableKeys.ts
@@ -1,8 +1,6 @@
 export const editableKeys = new Set([
   "wheelchair",
   "wheelchair:description",
-  "wheelchair:description:de",
-  "wheelchair:description:en",
-  "wheelchair:description:es",
   "toilets:wheelchair",
+  "description",
 ]);

--- a/src/lib/model/osm/tag-config/getOSMTagProps.ts
+++ b/src/lib/model/osm/tag-config/getOSMTagProps.ts
@@ -111,6 +111,7 @@ export function getOSMTagProps({
   const isEditable = editableKeys.has(key);
   const { hasLanguageTagSupport } =
     normalizeAndExtractLanguageTagsIfPresent(key);
+  const isDescription = key.includes("description");
 
   return {
     tagKey: key,
@@ -120,6 +121,7 @@ export function getOSMTagProps({
     valueAttribute,
     valueElement: valueLabel,
     isEditable,
+    isDescription,
     isLanguageTagged: hasLanguageTagSupport,
     valueDetails,
     keyDetails,


### PR DESCRIPTION
![GIF](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExeXZzdHh3c280d2RmYXp3OTdhZ2ptNWcweGxwaWgyM2I0em40bmd3ayZlcD12MV9naWZzX3NlYXJjaCZjdD1n/nvUQdK0AVjLqmuHgP5/giphy.gif)

##  🖊️ Description
**💡 What? Why? How?**
The edit button and drop down was falsely shown for non-editable tags which led to opening a placeholder editor in the middle of the feature panel.
I added a check for whether the tag is a description tag and made the auto editor open the string field editor for all description tags. I removed the edit buttons for non-editable tags.
I decided to not include any tests for this fix, since the test would belong to the feature panel domain and not directly to the editors. Since we are planning to rework the feature panel completely, writing a test at this point seemed to create more overhead, since the tests might have to be rewritten, too .

[*📎 Related Ticket*](https://app.asana.com/1/1200321573365931/project/1207846019025914/task/1209948930423673?focus=true)


## ⚠️ Creation checklist

<details><summary>💪 I have tested my code</summary>
  
  - [ ] The feature deployment works.
  - [ ] The automated tests are passing.
  - [ ] I have manually tested this feature
    - [ ] on mobile
    - [ ] by using keyboard-only navigation
    - [ ] with a screen reader (VoiceOver is fine)
    - [x] in Chrome
    - [x] in Firefox
    - [ ] in Safari
</details>

<details><summary>🧼 I have cleaned up my code</summary>
  
- [x] My code does not generate new warnings.
- [x] My code does not depend on new vulnerable packages.
- [x] The commit messages are precise and make sense (rebase the PR with `--interactive` if applicable, keeping commits in sensible chunks if possible).
</details>

<details><summary>🔍 I have performed a self-review of my code</summary>
  
- [x] My code is self-documenting or has links to necessary documentation.
</details> 

<details><summary>✨ I have created a nice pull request</summary>
  
- [x] It has a clear title.
- [x] It follows the template, has a clear description and testing instructions if needed.
- [x] It references applicable Asana tickets.
- [x] It targets the right branch.
- [x] I removed not applicable sections of the PR template.
- [ ] [optional] I added a GIF of my favorite animal to the PR description to lighten the mood of my colleagues.
</details> 


## 🔍 Reviewing

**When reviewing this merge request, here are some things to keep in mind:**

- [GitLab Code Review Guidelines](https://docs.gitlab.com/ee/development/code_review.html#reviewing-a-merge-request)
- [Conventional Comments](https://conventionalcomments.org/#format)

## 🔬  Testing instructions

Visit amenities/node:3856100103. This feature contains descriptions in multiple languages that are editable now, whereas the "operator" tag is not editable anymore.
