### PR TITLE
fix: focus on onboarding button causing parent page of widget to scroll

### DIFF
--- a/src/components/ModalDialog.tsx
+++ b/src/components/ModalDialog.tsx
@@ -14,9 +14,14 @@ type Props = {
   ariaLabel: string,
   ariaDescribedBy: string,
   children: React.ReactNode,
+  focusTrapActiveFromStart?: boolean
 };
 
 function ModalDialog(props: Props) {
+  const [focusTrapActive, setFocusTrapActive] = React.useState(
+      props.focusTrapActiveFromStart === undefined ? true : props.focusTrapActiveFromStart
+  );
+
   const isVisible = props.isVisible;
 
   if (!isVisible) {
@@ -24,7 +29,7 @@ function ModalDialog(props: Props) {
   }
 
   return (
-    <FocusTrap>
+    <FocusTrap active={focusTrapActive} onClick={() => !focusTrapActive && setFocusTrapActive(true)}>
       <section
         className={`modal-dialog ${props.className ? props.className : ''} ${
           !isVisible ? 'modal-dialog-hidden' : ''

--- a/src/components/Onboarding/Onboarding.tsx
+++ b/src/components/Onboarding/Onboarding.tsx
@@ -47,10 +47,6 @@ const Onboarding: React.FC<Props> = ({className, isVisible, onClose, clientSideC
 
   const headerMarkdownHTML = headerMarkdown && parse(translatedStringFromObject(headerMarkdown));
 
-  useEffect(() => {setTimeout(() => {
-    callToActionButton.current?.focus();
-  }, 100)}, [callToActionButton]);
-
   return (
     <ModalDialog
       className={className}
@@ -58,6 +54,7 @@ const Onboarding: React.FC<Props> = ({className, isVisible, onClose, clientSideC
       onClose={handleClose}
       ariaDescribedBy="wheelmap-claim-onboarding wheelmap-icon-descriptions"
       ariaLabel={t`Start screen`}
+      focusTrapActiveFromStart={false}
     >
       <header>
         <VectorImage
@@ -150,7 +147,7 @@ const Onboarding: React.FC<Props> = ({className, isVisible, onClose, clientSideC
       </footer>
       <Version>{env.npm_package_version}</Version>
     </ModalDialog>
-  ); 
+  );
 }
 
 const Version = styled.div`


### PR DESCRIPTION
##  🖊️ Description
**💡 What? Why? How?**

On https://www.fehmarn.de/service/barrierefreiheit the wheelmap widget is included via iframe. When loading the parent page and accepting all the cookies, the page automatically scrolls down to the wheelmap widget. But only if the onboarding modal is still visible.

The automatic focus on the cta in the onboarding component as well as the FocusTrap of the ModalDialog programmatically change the focus on load. This causes the parent page to scroll down.

This fix disabled the FocusTrap on first load until it is interacted with. I also removed the automatic focus of the cta. While this is not perfect, I guess it's an okay solution for now.

**📎 Related Ticket**

https://app.asana.com/1/1200321573365931/project/1208833037492986/task/1209974507152900?focus=true

## ⚠️ Creation checklist

**Before creating this merge request, go over the following checklist (click to expand). 
Remove any items that are not applicable.**

<details><summary>💪 I have tested my code</summary>
  
  - [ ] A new E2e playwright test covers this feature / A new test that reproduces the bug passes now.
  - [ ] The feature deployment works.
  - [ ] The automated tests are passing.
  - [ ] I have manually tested this feature
    - [ ] on mobile
    - [ ] by using keyboard-only navigation
    - [ ] with a screen reader (VoiceOver is fine)
    - [ ] in Chrome
    - [ ] in Firefox
    - [ ] in Safari
</details>

<details><summary>🧼 I have cleaned up my code</summary>
  
- [ ] I have removed dependencies that were just for testing.
- [ ] I have removed debug logging.
- [ ] My code does not generate new warnings.
- [ ] My code does not depend on new vulnerable packages.
- [ ] The commit messages are precise and make sense (rebase the PR with `--interactive` if applicable, keeping commits in sensible chunks if possible).
</details>

<details><summary>🔍 I have performed a self-review of my code</summary>
  
- [ ] My code is self-documenting or has links to necessary documentation.
- [ ] New function and variables names can be understood by new developers with basic project knowledge.
- [ ] The feature fits the design.
</details> 

<details><summary>✨ I have created a nice pull request</summary>
  
- [ ] It has a clear title.
- [ ] It follows the template, has a clear description and testing instructions if needed.
- [ ] It references applicable Asana tickets.
- [ ] It targets the right branch.
- [ ] I removed not applicable sections of the PR template.
- [ ] [optional] I added a GIF of my favorite animal to the PR description to lighten the mood of my colleagues.
</details> 

<details><summary>📝 I updated the documentation</summary>
  
- [ ] I updated the documentation in this repository.
- [ ] I updated the [tech manual](https://manual.i.wheelmap.tech/).
- [ ] I updated the manual testing plan of the app so that it includes a testing flow for this feature.
</details> 


## 🔍 Reviewing

**When reviewing this merge request, here are some things to keep in mind:**

- [GitLab Code Review Guidelines](https://docs.gitlab.com/ee/development/code_review.html#reviewing-a-merge-request)
- [Conventional Comments](https://conventionalcomments.org/#format)

## 🔬 Optional: Testing instructions

You can save the https://www.fehmarn.de/service/barrierefreiheit page including all assets to your system. Then open the HTML file and replace the link to the preview deployment or your locally running instance of the wheelmap.
