### PR TITLE
Fix mapping event start coordinates on Wheelmap production

### DIFF
--- a/src/MainView.tsx
+++ b/src/MainView.tsx
@@ -607,6 +607,7 @@ class MainView extends React.Component<Props, State> {
         feature={this.props.lightweightFeature || this.props.feature}
         featureId={featureId}
         mappingEvents={this.props.mappingEvents}
+        mappingEvent={this.props.mappingEvent}
         equipmentInfo={this.props.equipmentInfo}
         equipmentInfoId={equipmentInfoId}
         categories={this.props.categories}

--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -481,8 +481,8 @@ export default class Map extends React.Component<Props, State> {
   }
 
   handlePromiseResolved(
-    placeOrEquipmentPromise: Promise<Feature | EquipmentInfo | null>,
-    placeOrEquipment: Feature | EquipmentInfo | null
+    placeOrEquipmentPromise: Promise<Feature | EquipmentInfo | MappingEventFeature | null>,
+    placeOrEquipment: Feature | EquipmentInfo | MappingEventFeature | null
   ) {
     if (this.state.placeOrEquipmentPromise !== placeOrEquipmentPromise) {
       return;

--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -9,7 +9,7 @@ import includes from 'lodash/includes';
 import isEqual from 'lodash/isEqual';
 import * as React from 'react';
 import { t } from 'ttag';
-import { hrefForFeature } from '../../lib/Feature';
+import { hrefForFeature, MappingEventFeature } from '../../lib/Feature';
 import { currentLocales } from '../../lib/i18n';
 import HighlightableMarker from './HighlightableMarker';
 import LeafletLocateControl from './L.Control.Locate';
@@ -29,7 +29,7 @@ import {
 } from '../../lib/Feature';
 import { globalFetchManager } from '../../lib/FetchManager';
 import goToLocationSettings from '../../lib/goToLocationSettings';
-import { MappingEvents } from '../../lib/MappingEvent';
+import { MappingEvent, MappingEvents } from '../../lib/MappingEvent';
 import { normalizeCoordinate, normalizeCoordinates } from '../../lib/normalizeCoordinates';
 import { hasOpenedLocationHelp, saveState } from '../../lib/savedState';
 import shouldUseImperialUnits from '../../lib/shouldUseImperialUnits';
@@ -85,6 +85,7 @@ type Props = {
   featureId?: string | number | null;
   feature?: PotentialPromise<Feature | null>;
   mappingEvents?: MappingEvents;
+  mappingEvent?: MappingEvent;
   equipmentInfoId?: string | null;
   equipmentInfo?: PotentialPromise<EquipmentInfo | null> | null;
 
@@ -132,8 +133,8 @@ type Props = {
 type State = {
   showZoomInfo?: boolean;
   showLocationNotAllowedHint: boolean;
-  placeOrEquipment?: Feature | EquipmentInfo | null;
-  placeOrEquipmentPromise?: Promise<Feature | EquipmentInfo | null> | null;
+  placeOrEquipment?: Feature | EquipmentInfo | MappingEventFeature | null;
+  placeOrEquipmentPromise?: Promise<Feature | EquipmentInfo | MappingEventFeature | null> | null;
   zoomedToFeatureId: string | null;
   category: RootCategoryEntry | null;
 };
@@ -251,9 +252,9 @@ export default class Map extends React.Component<Props, State> {
   }
 
   static getDerivedStateFromProps(props: Props, state: State): Partial<State> {
-    const { feature, equipmentInfo } = props;
+    const { feature, equipmentInfo, mappingEvent } = props;
 
-    const placeOrEquipment = equipmentInfo || feature;
+    const placeOrEquipment = equipmentInfo || feature || mappingEvent?.meetingPoint;
 
     const category = props.categoryId ? Categories.getRootCategory(props.categoryId) : null;
 

--- a/src/lib/Feature.ts
+++ b/src/lib/Feature.ts
@@ -240,6 +240,7 @@ export function getFeatureId(feature: Feature | EquipmentInfo | any): string | n
     typeof feature._id === 'string' && feature._id,
     properties && typeof properties.id === 'number' && properties.id,
     properties && typeof properties._id === 'string' && properties._id,
+    properties && typeof properties.osm_id === 'number' && properties.osm_id,
   ];
   const result = idProperties.filter(Boolean)[0];
   return result ? String(result) : null;


### PR DESCRIPTION
##  🖊️ Description
**💡 What? Why? How?**

This fixes start geo-coordinates when joining a mapping event. Note that this goes directly into the production branch.

**📎 Related Ticket**

https://app.asana.com/1/1200321573365931/project/1207796258397451/task/1210578985029012?focus=true

## ⚠️ Creation checklist

**Before creating this merge request, go over the following checklist (click to expand). 
Remove any items that are not applicable.**

<details><summary>💪 I have tested my code</summary>
  
  - [ ] A new E2e playwright test covers this feature / A new test that reproduces the bug passes now.
  - [ ] The feature deployment works.
  - [ ] The automated tests are passing.
  - [x] I have manually tested this feature
    - [ ] on mobile
    - [ ] by using keyboard-only navigation
    - [ ] with a screen reader (VoiceOver is fine)
    - [x] in Chrome
    - [ ] in Firefox
    - [x] in Safari
</details>

## 🔬 Optional: Testing instructions

To test, open any mapping event in an incognito browser. The location should be the one that is set in the mapping event.